### PR TITLE
set observation date input to readonly

### DIFF
--- a/src/app/individual/phenophase-dialog.component.html
+++ b/src/app/individual/phenophase-dialog.component.html
@@ -11,6 +11,7 @@
       (dateInput)="data.observation.toNullable().date = $event.value.toDate()"
       [min]="data.limits.start_day"
       [max]="data.limits.end_day"
+      readonly
     />
     <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
     <mat-datepicker #picker></mat-datepicker>


### PR DESCRIPTION
Fixes #19 by setting the input field for observations to read-only.