### PR TITLE
Fix ngcc building issues

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,10 +17,10 @@ jobs:
         uses: actions/checkout@master
       - name: Install Dependencies
         run: | 
-          npm ci --only=prod --unsafe-perm
           npm install @angular/cli --no-save
+          npm ci --only=prod --unsafe-perm
       - name: Build
-        run: npx ng build --aot
+        run: npx ng build
       - name: Archive PR Artifact
         uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@master
       - name: Install Dependencies
         run: | 
-          npm ci --only=prod
+          npm ci --only=prod --unsafe-perm
           npm install @angular/cli --no-save
       - name: Build
         run: npx ng build --aot

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,8 +17,7 @@ jobs:
         uses: actions/checkout@master
       - name: Install Dependencies
         run: | 
-          npm install @angular/cli --no-save
-          npm ci --unsafe-perm
+          npm ci
       - name: Build
         run: npx ng build
       - name: Archive PR Artifact

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Dependencies
         run: | 
           npm install @angular/cli --no-save
-          npm ci --only=prod --unsafe-perm
+          npm ci --unsafe-perm
       - name: Build
         run: npx ng build
       - name: Archive PR Artifact


### PR DESCRIPTION
As ngcc is invoked as post-build-hook the angular-cli is already required to be installed by npm right away.