### PR TITLE
fix wrong positives of missing translations

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -22,7 +22,6 @@ export class AppComponent {
     browserUpdate({
       api: 2018.12,
       required: { e: 14, f: 60, o: 53, s: 11, c: 67 },
-      // text: translation,
       l: languageService.determineCurrentLang()
     });
 

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -3,7 +3,7 @@ import { NgModule, Optional, SkipSelf } from '@angular/core';
 import { MaterialModule } from './material.module';
 
 import { TranslateService } from '@ngx-translate/core';
-import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
+import { TranslateModule } from '@ngx-translate/core';
 
 import { AuthModule } from '../auth/auth.module';
 import { AuthService } from '../auth/auth.service';
@@ -17,7 +17,6 @@ import { AlertService } from '../messaging/alert.service';
 import { AlertComponent } from '../messaging/alert.component';
 import { NavService } from './nav/nav.service';
 import { LanguageService } from './language.service';
-import { ProfileModule } from '../profile/profile.module';
 
 /**
  * The `CoreModule` is used to group singleton services like {@link ExceptionService} and single-use components like {@link NavComponent}.

--- a/src/app/core/nav/nav.component.ts
+++ b/src/app/core/nav/nav.component.ts
@@ -1,9 +1,5 @@
-import { Component, ViewChild, ElementRef } from '@angular/core';
-import { TranslateService } from '@ngx-translate/core';
+import { Component } from '@angular/core';
 import { AuthService } from '../../auth/auth.service';
-import { LanguageService } from '../language.service';
-import { MatMenuTrigger } from '@angular/material/menu';
-import { MatSelectChange } from '@angular/material/select';
 
 @Component({
   selector: 'app-nav',
@@ -11,24 +7,9 @@ import { MatSelectChange } from '@angular/material/select';
   styleUrls: ['./nav.component.scss']
 })
 export class NavComponent {
-  @ViewChild(MatMenuTrigger) searchMenuTrigger: MatMenuTrigger;
-  @ViewChild('searchField') searchField: ElementRef;
-
-  constructor(
-    private languageService: LanguageService,
-    private translateService: TranslateService,
-    private authService: AuthService
-  ) {}
+  constructor(private authService: AuthService) {}
 
   isLoggedIn(): boolean {
     return this.authService.isLoggedIn();
-  }
-
-  nickname(): string {
-    return this.authService.getUserNickname();
-  }
-
-  logout() {
-    this.authService.logout();
   }
 }

--- a/src/app/login/register.component.ts
+++ b/src/app/login/register.component.ts
@@ -1,5 +1,5 @@
 import { AngularFireAnalytics } from '@angular/fire/analytics';
-import { AfterViewChecked, Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';

--- a/src/app/shared/SentryMissingTranslationHandler.ts
+++ b/src/app/shared/SentryMissingTranslationHandler.ts
@@ -4,6 +4,12 @@ import { environment } from 'src/environments/environment';
 
 export class SentryMissingTranslationHandler implements MissingTranslationHandler {
   handle(params: MissingTranslationHandlerParams) {
+    // bugfix for wrong positives
+    if (this.checkTranslationError(params)) {
+      return params.key;
+    }
+
+    // ignore numbers and missing translations is german
     if (params.translateService.currentLang !== 'de-CH' && !Number(params.key)) {
       if (environment.name === 'local') {
         console.log(this.getMsg(params));
@@ -15,5 +21,16 @@ export class SentryMissingTranslationHandler implements MissingTranslationHandle
 
   getMsg(params: MissingTranslationHandlerParams) {
     return 'Translation Error: ' + params.key + ' not found for ' + params.translateService.currentLang;
+  }
+
+  /*
+   * Check if the module was already loaded.
+   * On initial page load the missing translations handler is called
+   * once only with the default language causing false positives when
+   * reporting missing translations.
+   */
+
+  checkTranslationError(params: MissingTranslationHandlerParams) {
+    return !params.translateService.translations[params.translateService.currentLang];
   }
 }


### PR DESCRIPTION
fix wrong positives of missing translations.

Check if the language module was already loaded.
On initial page load the missing translations handler is called
once only with the default language. Causing false positives when
reporting missing translations.

+ some refactoring and corrections in the nav.service

closes #29 - once again