### PR TITLE
fix saving with empty comment #28

### DIFF
--- a/src/app/individual/individual-detail/individual-observation-view/individual-observation-view.component.ts
+++ b/src/app/individual/individual-detail/individual-observation-view/individual-observation-view.component.ts
@@ -18,6 +18,7 @@ import { Individual } from '../../individual';
 import { PhenophaseDialogComponent } from '../../phenophase-dialog.component';
 import { findFirst } from 'fp-ts/lib/Array';
 import { altitudeLimits } from 'src/app/masterdata/altitude-limits';
+import firebase from 'firebase/app';
 
 @Component({
   selector: 'app-individual-observation-view',
@@ -107,9 +108,14 @@ export class ObservationViewComponent implements OnInit {
     });
 
     dialogRef.afterClosed().subscribe((result: PhenophaseObservation) => {
-      if (result) {
+      // discard result if empty or no data was selected (fixme -> disable button in form)
+      if (result && result.observation.toNullable().date) {
         this.individual$.pipe(first()).subscribe(detail => {
           result.observation.map(observation => {
+            // fix undefined comment #28
+            if (observation.comment === undefined) {
+              observation.comment = firebase.firestore.FieldValue.delete();
+            }
             // if this is a new observation the created date is not set
             if (!observation.created) {
               observation.individual = detail.individual;

--- a/src/app/observation/observation.ts
+++ b/src/app/observation/observation.ts
@@ -1,3 +1,6 @@
+import firebase from 'firebase/app';
+import FieldValue = firebase.firestore.FieldValue;
+
 export class Observation {
   date: Date;
   individual: string;
@@ -6,7 +9,7 @@ export class Observation {
   species: string;
   year: number;
   user: string;
-  comment: string | null;
+  comment: string | FieldValue;
   created: Date;
   modified: Date;
   source: 'globe' | 'meteoswiss';


### PR DESCRIPTION
Fix errors when saving observation data with empty comment.

Settings empty comment now also removes present comments.

closes #28 