### PR TITLE
do not override host in firebase settings

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -85,7 +85,7 @@ registerLocaleData(localeIt, 'it');
     UserService,
     IndividualService,
     // workaround for https://github.com/firebase/firebase-js-sdk/issues/1674 remove when fixed in the SDK
-    { provide: SETTINGS, useValue: { experimentalForceLongPolling: true } }
+    { provide: SETTINGS, useValue: { experimentalForceLongPolling: true, merge: true } }
     // { provide: DEBUG_MODE, useValue: true }
   ],
   bootstrap: [AppComponent]


### PR DESCRIPTION
The app was showing warning that the host was overridden.

`You are overriding the original host. If you did not intend to override your settings, use {merge: true}.`