### PR TITLE
fix user subscription

### DIFF
--- a/src/app/core/base-resource.service.ts
+++ b/src/app/core/base-resource.service.ts
@@ -1,6 +1,7 @@
 import { AngularFirestore } from '@angular/fire/compat/firestore';
 import { from, identity, Observable } from 'rxjs';
 import { first, mergeMap } from 'rxjs/operators';
+import { IdLike } from '../masterdata/masterdata-like';
 import { AlertService } from '../messaging/alert.service';
 import { BaseService } from './base.service';
 import { ResourceService } from './resource.service';
@@ -32,11 +33,12 @@ export abstract class BaseResourceService<T> extends BaseService implements Reso
     ).pipe(mergeMap(identity));
   }
 
-  get(id: string, withId = false): Observable<T> {
-    return this.afs
-      .collection<T>(this.collectionName)
-      .doc<T>(id)
-      .valueChanges(withId ? { idField: 'id' } : undefined);
+  get(id: string): Observable<T> {
+    return this.afs.collection<T>(this.collectionName).doc<T>(id).valueChanges();
+  }
+
+  getWithId(id: string): Observable<T & IdLike> {
+    return this.afs.collection<T>(this.collectionName).doc<T>(id).valueChanges({ idField: 'id' });
   }
 
   /**

--- a/src/app/open/public-user.ts
+++ b/src/app/open/public-user.ts
@@ -1,5 +1,4 @@
 export class PublicUser {
-  id: string;
   nickname: string;
   roles?: string[];
 }

--- a/src/app/profile/profile/profile-public/profile-public.component.html
+++ b/src/app/profile/profile/profile-public/profile-public.component.html
@@ -19,6 +19,6 @@
     <button mat-icon-button [app-copy-clipboard]="profileLink" (copied)="notifyCopied()">
       <mat-icon svgIcon="copylink"></mat-icon>
     </button>
-    <app-user-subscription-button [user$]="user$" *ngIf="isLoggedIn"></app-user-subscription-button>
+    <app-user-subscription-button [userId]="userId" *ngIf="isLoggedIn"></app-user-subscription-button>
   </div>
 </div>

--- a/src/app/profile/profile/user-item/user-item.component.ts
+++ b/src/app/profile/profile/user-item/user-item.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
+import { IdLike } from 'src/app/masterdata/masterdata-like';
 import { PublicUser } from '../../../open/public-user';
 
 @Component({
@@ -6,9 +7,6 @@ import { PublicUser } from '../../../open/public-user';
   templateUrl: './user-item.component.html',
   styleUrls: ['./user-item.component.scss']
 })
-export class FollowUserComponent implements OnInit {
-  constructor() {}
-  @Input() item: PublicUser;
-
-  ngOnInit(): void {}
+export class FollowUserComponent {
+  @Input() item: PublicUser & IdLike;
 }

--- a/src/app/profile/user.service.ts
+++ b/src/app/profile/user.service.ts
@@ -57,21 +57,21 @@ export class UserService extends BaseResourceService<User> implements OnDestroy 
     );
   }
 
-  followUser(target: string | Observable<PublicUser>): Observable<void> {
+  followUser(target: string | Observable<PublicUser & IdLike>): Observable<void> {
     return this.idObservable(target).pipe(
       first(),
       switchMap(id => this.followUnfollow({ following_users: firebase.firestore.FieldValue.arrayUnion(id) }))
     );
   }
 
-  unfollowUser(target: string | Observable<PublicUser>): Observable<void> {
+  unfollowUser(target: string | Observable<PublicUser & IdLike>): Observable<void> {
     return this.idObservable(target).pipe(
       first(),
       switchMap(id => this.followUnfollow({ following_users: firebase.firestore.FieldValue.arrayRemove(id) }))
     );
   }
 
-  isFollowingUser(target: string | Observable<PublicUser>): Observable<boolean> {
+  isFollowingUser(target: string | Observable<PublicUser & IdLike>): Observable<boolean> {
     return combineLatest([this.idObservable(target), this.getUser()]).pipe(
       map(([id, user]) => (user.following_users ? user.following_users.includes(id) : false))
     );
@@ -99,12 +99,12 @@ export class UserService extends BaseResourceService<User> implements OnDestroy 
     );
   }
 
-  getFollowedUsers(limit$: Observable<number>): Observable<PublicUser[]> {
+  getFollowedUsers(limit$: Observable<number>): Observable<(PublicUser & IdLike)[]> {
     return combineLatest([this.authService.user$, limit$]).pipe(
       filter(([user]) => user.following_users !== undefined && user.following_users.length !== 0),
       switchMap(([user_ids, limit]) =>
         combineLatest(
-          user_ids.following_users.slice(0, limit).map(user_id => this.publicUserService.get(user_id, true))
+          user_ids.following_users.slice(0, limit).map(user_id => this.publicUserService.getWithId(user_id))
         )
       )
     );

--- a/src/app/shared/subscription/user-subscription-button/user-subscription-button.component.ts
+++ b/src/app/shared/subscription/user-subscription-button/user-subscription-button.component.ts
@@ -2,7 +2,6 @@ import { Component, Input, OnInit } from '@angular/core';
 import { AngularFireAnalytics } from '@angular/fire/compat/analytics';
 import { Observable } from 'rxjs';
 import { AlertService } from 'src/app/messaging/alert.service';
-import { PublicUser } from 'src/app/open/public-user';
 import { PublicUserService } from 'src/app/open/public-user.service';
 import { UserService } from 'src/app/profile/user.service';
 
@@ -12,7 +11,6 @@ import { UserService } from 'src/app/profile/user.service';
   styleUrls: ['./user-subscription-button.component.scss']
 })
 export class UserSubscriptionButtonComponent implements OnInit {
-  @Input() user$: Observable<PublicUser>;
   @Input() userId: string;
   isFollowing$: Observable<boolean>;
 
@@ -24,31 +22,28 @@ export class UserSubscriptionButtonComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    if (!this.user$) {
-      this.user$ = this.publicUserService.get(this.userId);
-    }
-    this.isFollowing$ = this.userService.isFollowingUser(this.user$);
+    this.isFollowing$ = this.userService.isFollowingUser(this.userId);
   }
 
   follow(): void {
     this.userService
-      .followUser(this.user$)
+      .followUser(this.userId)
       .subscribe(() =>
         this.alertService.infoMessage('Aktivitäten abonniert', 'Sie haben die Aktivitäten des Benutzers abonniert.')
       );
 
-    this.analytics.logEvent('follow-user');
+    void this.analytics.logEvent('follow-user');
   }
 
   unfollow(): void {
     this.userService
-      .unfollowUser(this.user$)
+      .unfollowUser(this.userId)
       .subscribe(() =>
         this.alertService.infoMessage(
           'Aktivitäten gekündigt',
           'Sie erhalten keine Aktivitäten mehr zu diesem Benutzer.'
         )
       );
-    this.analytics.logEvent('unfollow-user');
+    void this.analytics.logEvent('unfollow-user');
   }
 }


### PR DESCRIPTION
User subscription was presumably broken in #239 when the public user creation was changed to no contain the ID automatically.

* PublicUser type should not have had the id in the first place, so it was removed
* base-resource now provide two get functions `get` and `getWithId` where both return the proper type.
* the following/unfollowing user service methods were fixed to depend on IdLike observables
* following/unfollowing was changed to use user IDs instead of publicUser observables. Including the Id would need changes specific to this case in the base resource service.