### PR TITLE
debug firestore read/write access

### DIFF
--- a/src/app/activity/activity.service.ts
+++ b/src/app/activity/activity.service.ts
@@ -1,14 +1,16 @@
 import { Injectable } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/compat/firestore';
 import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
 import { BaseResourceService } from '../core/base-resource.service';
 import { AlertService } from '../messaging/alert.service';
+import { FirestoreDebugService } from '../shared/firestore-debug.service';
 import { Activity } from './activity';
 
 @Injectable()
 export class ActivityService extends BaseResourceService<Activity> {
-  constructor(alertService: AlertService, protected afs: AngularFirestore) {
-    super(alertService, afs, 'activities');
+  constructor(alertService: AlertService, protected afs: AngularFirestore, protected fds: FirestoreDebugService) {
+    super(alertService, afs, 'activities', fds);
   }
 
   listByUser(userId: string, limit: number = 8): Observable<Activity[]> {
@@ -16,6 +18,7 @@ export class ActivityService extends BaseResourceService<Activity> {
       .collection<Activity>('activities', ref =>
         ref.where('followers', 'array-contains', userId).orderBy('activity_date', 'desc').limit(limit)
       )
-      .valueChanges();
+      .valueChanges()
+      .pipe(tap(x => this.fds.addRead('activities (listByUser)', x.length)));
   }
 }

--- a/src/app/profile/invite/invite.service.ts
+++ b/src/app/profile/invite/invite.service.ts
@@ -2,11 +2,13 @@ import { Injectable } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/compat/firestore';
 import firebase from 'firebase/compat/app';
 import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
 import { AuthService } from 'src/app/auth/auth.service';
 import { BaseResourceService } from 'src/app/core/base-resource.service';
 import { LanguageService } from 'src/app/core/language.service';
 import { IdLike } from 'src/app/masterdata/masterdata-like';
 import { AlertService } from 'src/app/messaging/alert.service';
+import { FirestoreDebugService } from 'src/app/shared/firestore-debug.service';
 import { Invite } from './invite';
 
 @Injectable({
@@ -17,9 +19,10 @@ export class InviteService extends BaseResourceService<Invite> {
     protected alertService: AlertService,
     protected afs: AngularFirestore,
     protected authService: AuthService,
-    protected languageService: LanguageService
+    protected languageService: LanguageService,
+    protected fds: FirestoreDebugService
   ) {
-    super(alertService, afs, 'invites');
+    super(alertService, afs, 'invites', fds);
   }
 
   addInvite(email: string) {
@@ -35,7 +38,8 @@ export class InviteService extends BaseResourceService<Invite> {
   getInvites(): Observable<(Invite & IdLike)[]> {
     return this.afs
       .collection<Invite>(this.collectionName, ref => ref.where('user', '==', this.authService.getUserId()))
-      .valueChanges({ idField: 'id' });
+      .valueChanges({ idField: 'id' })
+      .pipe(tap(x => this.fds.addRead('activities (getInvites)', x.length)));
   }
 
   resendInvite(invite: Invite, id: string) {

--- a/src/app/profile/user.ts
+++ b/src/app/profile/user.ts
@@ -4,6 +4,6 @@ export class User {
   lastname: string;
   locale: string;
 
-  following_users: string[];
-  following_individuals: string[];
+  following_users?: string[];
+  following_individuals?: string[];
 }

--- a/src/app/shared/firestore-debug.service.ts
+++ b/src/app/shared/firestore-debug.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@angular/core';
+import * as Sentry from '@sentry/angular';
+import { environment } from 'src/environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FirestoreDebugService {
+  private readcnt: Map<string, number> = new Map();
+  private writecnt: Map<string, number> = new Map();
+  private lastSentrySend = 1;
+
+  public addRead(key: string, amt = 1): void {
+    this.count(this.readcnt, 'read', key, amt);
+  }
+
+  public addWrite(key: string, amt = 1): void {
+    this.count(this.writecnt, 'write', key, amt);
+  }
+
+  private count(map: Map<string, number>, type: string, key: string, amt: number) {
+    if (environment.debugFirestore) {
+      const oldcnt = map.get(key) || 0;
+      map.set(key, oldcnt + amt);
+      if (!environment.production) {
+        console.log(`${type}: ${key} -> ${oldcnt + amt} (+${amt})`);
+      }
+
+      if (environment.sentryEnabled && oldcnt / 1000 > this.lastSentrySend) {
+        Sentry.captureMessage('High Firestore access', {
+          level: Sentry.Severity.Debug,
+          extra: { counters: this.map2obj(map) }
+        });
+        this.lastSentrySend += 1;
+      }
+    }
+  }
+
+  private map2obj(map: Map<string, number>) {
+    return Array.from(map).reduce((obj, [key, value]) => {
+      obj[key] = value;
+      return obj;
+    }, {});
+  }
+
+  public show(): void {
+    console.log(this.readcnt);
+    console.log(this.writecnt);
+  }
+}

--- a/src/app/statistics/statistics.service.ts
+++ b/src/app/statistics/statistics.service.ts
@@ -1,17 +1,18 @@
 import { Injectable } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/compat/firestore';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { map, tap } from 'rxjs/operators';
 import { BaseResourceService } from '../core/base-resource.service';
 import { SourceFilterType } from '../masterdata/source-type';
 import { AlertService } from '../messaging/alert.service';
+import { FirestoreDebugService } from '../shared/firestore-debug.service';
 import { Analytics } from './analytics';
 import { AnalyticsType } from './analytics-type';
 
 @Injectable()
 export class StatisticsService extends BaseResourceService<Analytics> {
-  constructor(alertService: AlertService, protected afs: AngularFirestore) {
-    super(alertService, afs, 'analytics_result');
+  constructor(alertService: AlertService, protected afs: AngularFirestore, protected fds: FirestoreDebugService) {
+    super(alertService, afs, 'analytics_result', fds);
   }
 
   listByYear(
@@ -36,6 +37,7 @@ export class StatisticsService extends BaseResourceService<Analytics> {
       })
       .valueChanges({ idField: 'id' })
       .pipe(
+        tap(x => this.fds.addRead(`${this.collectionName} (listByYear)`, x.length)),
         map(analytics =>
           analytics.map(a => ({
             source: a.source,

--- a/src/environments/environment.local.ts
+++ b/src/environments/environment.local.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: false,
+  debugFirestore: true,
   name: 'local',
   sentrySamplerate: 1.0,
   sentryEnabled: false,

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -4,6 +4,7 @@
 
 export const environment = {
   production: true,
+  debugFirestore: true,
   name: 'production',
   sentrySamplerate: 1.0,
   sentryEnabled: true,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: false,
+  debugFirestore: false,
   name: 'test',
   sentrySamplerate: 1.0,
   sentryEnabled: true,


### PR DESCRIPTION
* count read/write access to Firestore
* send debug info to sentry
* reuse map observables

Observables for the map view will be cached and reused. Before every change in the filter triggered a reload of all observations displayed on the map.
This should considerably lower the amounts of reads occurring from the clients. The only downside is that changes in the data will trigger a reload of the map documents even if the user is not on the map view.
To reduce reads even more we can consider local caching with snapshot listeners, see [How to drastically reduce the number of reads when no documents are changed in Firestore?](https://medium.com/firebase-tips-tricks/how-to-drastically-reduce-the-number-of-reads-when-no-documents-are-changed-in-firestore-8760e2f25e9e)
