### PR TITLE
Fix errors on individual deletion

### DIFF
--- a/src/app/core/base-detail.component.ts
+++ b/src/app/core/base-detail.component.ts
@@ -1,7 +1,7 @@
 import { Directive, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { Observable, of, ReplaySubject, Subscription, throwError } from 'rxjs';
-import { flatMap, switchMap, tap } from 'rxjs/operators';
+import { filter, flatMap, switchMap, tap } from 'rxjs/operators';
 import { ResourceService } from './resource.service';
 
 @Directive()
@@ -25,7 +25,8 @@ export class BaseDetailComponent<T> implements OnInit, OnDestroy {
             if (!subject) {
               void this.router.navigate(['/404'], { skipLocationChange: true });
             }
-          })
+          }),
+          filter(subject => subject !== undefined) // do not publish undefined values (after subject deletion)
         )
         .subscribe(this.detailSubject$)
     );

--- a/src/app/individual/individual.service.ts
+++ b/src/app/individual/individual.service.ts
@@ -172,7 +172,13 @@ export class IndividualService extends BaseResourceService<Individual> {
   }
 
   deleteImages(individual: Individual): void {
-    void this.afStorage.storage.ref(this.getImagePath(individual, true)).delete();
-    void this.afStorage.storage.ref(this.getImagePath(individual, false)).delete();
+    this.afStorage.storage
+      .ref(this.getImagePath(individual, true))
+      .delete()
+      .catch(() => null); // ignore if image does not exist
+    this.afStorage.storage
+      .ref(this.getImagePath(individual, false))
+      .delete()
+      .catch(() => null); // ignore if image does not exist
   }
 }


### PR DESCRIPTION
* Do not publish undefined subjects on deletion. This was causing a lot of errors if the individual view was opened at the same time (e.g. in another tab).
* catch error if deleted individual image does not exist as this is to be expected in no image was uploaded for that individual