### PR TITLE
limit codacy runtime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,7 @@ jobs:
           upload: true
           verbose: true
           parallel: 10
+          tool-timeout: 5minutes
   checks:
     name: run checks
     runs-on: ubuntu-latest


### PR DESCRIPTION
Limit runtime to 5 minutes and therefore abort broken duplication tests.

Unfortunately no luck disabling them.