### PR TITLE
disable build optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,12 @@ To manually deploy a test version:
 npx ng build && npx firebase deploy --project phaenonet-test
 ```
 
-### Manually deploy application to production
+### Manually deploy application version to production
 
 ```commandline
-npx ng build --c=production && npx firebase deploy --project phaenonet
+git checkout v<version>
+npx firebase login
+rm -r node_modules && npm ci --also=dev && npx ng build --c=production && npx firebase deploy --project phaenonet
 ```
 
 ## Related resources

--- a/angular.json
+++ b/angular.json
@@ -57,7 +57,7 @@
               "namedChunks": false,
               "extractLicenses": true,
               "vendorChunk": false,
-              "buildOptimizer": true,
+              "buildOptimizer": false,
               "budgets": [
                 {
                   "type": "initial",


### PR DESCRIPTION
Turn off buildOptimizer as it breaks the build causing errors like `TypeError: Gn.analytics is not a function`

see https://github.com/angular/angular-cli/issues/17255#issuecomment-456492270