### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/channel.yml
+++ b/.github/workflows/channel.yml
@@ -32,8 +32,8 @@ jobs:
     environment: ${{ github.event.inputs.project }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@v3.3.0
+      - uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install Dependencies
@@ -41,13 +41,13 @@ jobs:
       - name: Build
         run: npx ng build
       - name: Archive Test Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: ${{ env.PROJECT }}
           path: dist
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1.0.0
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,8 +34,8 @@ jobs:
     outputs:
       dbdocs: ${{ steps.filter.outputs.dbdocs }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
+      - uses: actions/checkout@v3.3.0
+      - uses: dorny/paths-filter@v2.11.1
         id: filter
         with:
           filters: |
@@ -46,8 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@v3.3.0
+      - uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install Dependencies
@@ -65,7 +65,7 @@ jobs:
       - name: Build
         run: npx ng build ${{ env.PROJECT == 'phaenonet' && '--c=production' || '' }}
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: ${{ env.PROJECT }}
           path: dist
@@ -75,13 +75,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
       - name: Download Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v3.0.2
         with:
           name: ${{ env.PROJECT }}
           path: dist
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install sentry-cli
@@ -109,29 +109,29 @@ jobs:
     environment: ${{ github.event.inputs.project || 'phaenonet-test' }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
       - name: Checkout rules
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
         with:
           repository: globe-swiss/phaenonet-client-security
           path: security
           ssh-key: ${{ secrets.SECURITY_REPO_DEPLOY_KEY }}
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1.0.0
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           create_credentials_file: true
       - name: Download Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v3.0.2
         with:
           name: ${{ env.PROJECT }}
           path: dist
       - name: Remove source maps (prod)
         run: rm ./dist/**/*.map
         if: ${{ env.PROJECT == 'phaenonet' }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: install firebase-tools
@@ -158,8 +158,8 @@ jobs:
     if: ${{ github.event.inputs.project == 'phaenonet' && needs.changes.outputs.dbdocs == 'true'}}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@v3.3.0
+      - uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: build & upload docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@v3.3.0
+      - uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Cache dependencies
         # check options to skip download in future versions
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.2
         with:
           path: ./node_modules
           key: module-${{ env.NODE_VERSION }}-${{ env.CACHE_SEQ }}-${{ hashFiles('package-lock.json') }}
@@ -36,24 +36,24 @@ jobs:
     needs: cache-deps
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@v3.3.0
+      - uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Cache dependencies
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.2
         with:
           path: ./node_modules
           key: module-${{ env.NODE_VERSION }}-${{ env.CACHE_SEQ }}-${{ hashFiles('package-lock.json') }}
       - name: Set API info
-        uses: wei/wget@v1
+        uses: wei/wget@v1.1.1
         with:
           args: -q -P ./src/local/ ${{ secrets.FIREBASE_TEST_API_URL }}
       - name: Build test version
         run: npx ng build -c local
       - name: Archive Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: dist-pr-build
           path: dist
@@ -67,13 +67,13 @@ jobs:
     needs: cache-deps
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@v3.3.0
+      - uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Cache dependencies
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.2
         with:
           path: ./node_modules
           key: module-${{ env.NODE_VERSION }}-${{ env.CACHE_SEQ }}-${{ hashFiles('package-lock.json') }}
@@ -82,21 +82,21 @@ jobs:
         env:
           JEST_JUNIT_OUTPUT_DIR: reports
       - name: Test Report
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v1.6.0
         with:
           name: Unit Tests Results
           path: reports/junit.xml
           reporter: jest-junit
         if: always()
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v3.1.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: reports/lcov.info
           flags: unittests
         if: always() && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
       - name: Run codacy-coverage-reporter
-        uses: codacy/codacy-coverage-reporter-action@v1
+        uses: codacy/codacy-coverage-reporter-action@v1.3.0
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: reports/lcov.info
@@ -108,11 +108,11 @@ jobs:
     needs: build
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@v3.3.0
+      - uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v3.0.2
         with:
           name: dist-pr-build
       - name: Start server
@@ -126,7 +126,7 @@ jobs:
       - name: e2e-test
         working-directory: e2e
         run: npx codeceptjs run --reporter mochawesome
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v3.1.2
         with:
           name: e2e-test-report
           path: e2e/output
@@ -138,18 +138,18 @@ jobs:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@v3.3.0
+      - uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Cache dependencies
         id: cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.2
         with:
           path: ./node_modules
           key: module-${{ env.NODE_VERSION }}-${{ env.CACHE_SEQ }}-${{ hashFiles('package-lock.json') }}
       - name: Codacy Analysis CLI
-        uses: codacy/codacy-analysis-cli-action@v4
+        uses: codacy/codacy-analysis-cli-action@v4.2.0
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           upload: true
@@ -160,8 +160,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@v3.3.0
+      - uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install Dependencies


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.3.0](https://github.com/actions/checkout/releases/tag/v3.3.0)** on 2023-01-05T13:21:21Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v3.1.1](https://github.com/codecov/codecov-action/releases/tag/v3.1.1)** on 2022-09-19T15:25:54Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v3.6.0](https://github.com/actions/setup-node/releases/tag/v3.6.0)** on 2023-01-05T14:09:37Z
* **[wei/wget](https://github.com/wei/wget)** published a new release **[v1.1.1](https://github.com/wei/wget/releases/tag/v1.1.1)** on 2019-08-11T03:33:51Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.2.2](https://github.com/actions/cache/releases/tag/v3.2.2)** on 2022-12-27T11:11:11Z
* **[codacy/codacy-analysis-cli-action](https://github.com/codacy/codacy-analysis-cli-action)** published a new release **[v4.2.0](https://github.com/codacy/codacy-analysis-cli-action/releases/tag/v4.2.0)** on 2022-09-20T16:18:43Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v3.1.2](https://github.com/actions/upload-artifact/releases/tag/v3.1.2)** on 2023-01-06T14:29:05Z
* **[dorny/test-reporter](https://github.com/dorny/test-reporter)** published a new release **[v1.6.0](https://github.com/dorny/test-reporter/releases/tag/v1.6.0)** on 2022-10-13T20:15:21Z
* **[google-github-actions/auth](https://github.com/google-github-actions/auth)** published a new release **[v1.0.0](https://github.com/google-github-actions/auth/releases/tag/v1.0.0)** on 2022-11-08T17:32:15Z
* **[codacy/codacy-coverage-reporter-action](https://github.com/codacy/codacy-coverage-reporter-action)** published a new release **[v1.3.0](https://github.com/codacy/codacy-coverage-reporter-action/releases/tag/v1.3.0)** on 2022-01-19T14:07:50Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v3.0.2](https://github.com/actions/download-artifact/releases/tag/v3.0.2)** on 2023-01-05T21:13:22Z
* **[dorny/paths-filter](https://github.com/dorny/paths-filter)** published a new release **[v2.11.1](https://github.com/dorny/paths-filter/releases/tag/v2.11.1)** on 2022-10-12T20:37:55Z
