### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/channel.yml
+++ b/.github/workflows/channel.yml
@@ -32,7 +32,7 @@ jobs:
       checks: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
       - uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
       - uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
       - name: Download Artifact
         uses: ./.github/actions/download-zip-artifact
         with:
@@ -96,9 +96,9 @@ jobs:
     environment: ${{ github.event.inputs.project || 'phaenonet-test' }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
       - name: Checkout rules
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
         with:
           repository: globe-swiss/phaenonet-client-security
           path: security
@@ -117,7 +117,7 @@ jobs:
         run: npm i --no-save firebase-tools
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1.0.0
+        uses: google-github-actions/auth@v1.1.1
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -143,7 +143,7 @@ jobs:
     if: ${{ github.event.inputs.project == 'phaenonet' }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
       - uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
       - uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -41,7 +41,7 @@ jobs:
     needs: cache-deps
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
       - uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -51,7 +51,7 @@ jobs:
           path: ./node_modules
           key: module-${{ env.NODE_VERSION }}-${{ env.CACHE_SEQ }}-${{ hashFiles('package-lock.json') }}
       - name: Set API info
-        uses: suisei-cn/actions-download-file@v1.3.0
+        uses: suisei-cn/actions-download-file@v1.4.0
         with:
           url: ${{ secrets.FIREBASE_TEST_API_URL }}
           target: ./src/local/
@@ -76,7 +76,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
       - name: Download Build Artifact
         uses: ./.github/actions/download-zip-artifact
         with:
@@ -98,7 +98,7 @@ jobs:
     needs: cache-deps
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
       - uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -119,7 +119,7 @@ jobs:
           reporter: jest-junit
         if: always()
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@v3.1.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: reports/lcov.info
@@ -138,7 +138,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
       - uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -181,7 +181,7 @@ jobs:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.5.2
       - uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -198,18 +198,18 @@ jobs:
           diff <(ls src/assets/img/map_pins/de-CH) <(ls src/assets/img/map_pins/it-CH) || exit
         if: ${{ always() }}
       - name: stylelint
-        uses: reviewdog/action-stylelint@v1
+        uses: reviewdog/action-stylelint@v1.16.0
         with:
           stylelint_input: '**/*.scss'
           reporter: github-pr-review
           fail_on_error: True
         if: always()
-      - uses: reviewdog/action-eslint@v1
+      - uses: reviewdog/action-eslint@v1.18.2
         with:
           reporter: github-pr-review
           fail_on_error: True
         if: always()
-      - uses: EPMatt/reviewdog-action-prettier@v1
+      - uses: EPMatt/reviewdog-action-prettier@v1.1.1
         with:
           reporter: github-pr-review
           fail_on_error: True

--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3.5.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.2
+        uses: saadmk11/github-actions-version-updater@v0.7.4
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[suisei-cn/actions-download-file](https://github.com/suisei-cn/actions-download-file)** published a new release **[v1.4.0](https://github.com/suisei-cn/actions-download-file/releases/tag/v1.4.0)** on 2023-05-12T15:07:38Z
* **[EPMatt/reviewdog-action-prettier](https://github.com/EPMatt/reviewdog-action-prettier)** published a new release **[v1.1.1](https://github.com/EPMatt/reviewdog-action-prettier/releases/tag/v1.1.1)** on 2023-03-06T15:15:24Z
* **[reviewdog/action-eslint](https://github.com/reviewdog/action-eslint)** published a new release **[v1.18.2](https://github.com/reviewdog/action-eslint/releases/tag/v1.18.2)** on 2023-03-04T10:57:11Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.2](https://github.com/actions/checkout/releases/tag/v3.5.2)** on 2023-04-13T12:49:40Z
* **[google-github-actions/auth](https://github.com/google-github-actions/auth)** published a new release **[v1.1.1](https://github.com/google-github-actions/auth/releases/tag/v1.1.1)** on 2023-05-08T18:19:27Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v3.1.4](https://github.com/codecov/codecov-action/releases/tag/v3.1.4)** on 2023-05-15T20:51:01Z
* **[reviewdog/action-stylelint](https://github.com/reviewdog/action-stylelint)** published a new release **[v1.16.0](https://github.com/reviewdog/action-stylelint/releases/tag/v1.16.0)** on 2023-03-04T11:06:27Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.7.4](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.7.4)** on 2023-03-15T16:41:04Z
