### PR TITLE
update plugins to stylelint v15

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,17 +1,18 @@
 {
   "extends": ["stylelint-config-sass-guidelines", "stylelint-config-prettier-scss"],
+  "plugins": ["stylelint-order"],
   "rules": {
-    "color-hex-length": "long",
-    "selector-max-id": 4,
-    "selector-max-compound-selectors": 4,
-    "selector-no-qualifying-type": null,
-    "order/properties-alphabetical-order": null,
-    "color-named": null,
-    "selector-pseudo-element-no-unknown": null,
-    "max-nesting-depth": 3,
-    "shorthand-property-no-redundant-values": null,
     "at-rule-empty-line-before": null,
+    "color-hex-length": "long",
+    "color-named": null,
     "comment-whitespace-inside": "always",
-    "declaration-empty-line-before": null
+    "declaration-empty-line-before": null,
+    "max-nesting-depth": 3,
+    "order/properties-alphabetical-order": null,
+    "selector-max-compound-selectors": 4,
+    "selector-max-id": 4,
+    "selector-no-qualifying-type": null,
+    "selector-pseudo-element-no-unknown": null,
+    "shorthand-property-no-redundant-values": null
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "lodash": "^4.17.21",
         "lz-string": "^1.4.4",
         "moment": "^2.29.4",
-        "postcss": "^8.4.29",
         "rxjs": "^7.5.6",
         "tslib": "^2.4.0",
         "zone.js": "~0.11.4"
@@ -76,6 +75,7 @@
         "jest": "^28.1.3",
         "jest-junit": "^14.0.1",
         "jest-preset-angular": "^12.2.0",
+        "postcss": "^8.4.29",
         "prettier": "2.8.0",
         "stylelint": "^15.2.0",
         "stylelint-config-prettier-scss": "^1.0.0",
@@ -23196,6 +23196,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
       "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -24478,6 +24479,7 @@
       "version": "8.4.29",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.29.tgz",
       "integrity": "sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -26068,6 +26070,7 @@
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "lodash": "^4.17.21",
         "lz-string": "^1.4.4",
         "moment": "^2.29.4",
+        "postcss": "^8.4.29",
         "rxjs": "^7.5.6",
         "tslib": "^2.4.0",
         "zone.js": "~0.11.4"
@@ -77,9 +78,9 @@
         "jest-preset-angular": "^12.2.0",
         "prettier": "2.8.0",
         "stylelint": "^15.2.0",
-        "stylelint-config-prettier-scss": "0.0.1",
-        "stylelint-config-sass-guidelines": "^9.0.1",
-        "stylelint-prettier": "^3.0.0",
+        "stylelint-config-prettier-scss": "^1.0.0",
+        "stylelint-config-sass-guidelines": "^10.0.0",
+        "stylelint-order": "^6.0.3",
         "ts-mockito": "^2.6.1",
         "ts-node": "~8.1.0",
         "typescript": "~4.9.5"
@@ -286,6 +287,30 @@
         "tailwindcss": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular-devkit/build-angular/node_modules/postcss": {
+      "version": "8.4.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/rxjs": {
@@ -6868,7 +6893,7 @@
     },
     "node_modules/accepts": {
       "version": "1.3.8",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
@@ -6880,7 +6905,7 @@
     },
     "node_modules/acorn": {
       "version": "8.8.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -6919,7 +6944,7 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -6960,7 +6985,7 @@
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -7044,7 +7069,7 @@
     },
     "node_modules/ansi-align": {
       "version": "3.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.1.0"
@@ -7102,7 +7127,7 @@
     },
     "node_modules/ansicolors": {
       "version": "0.3.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
@@ -7140,7 +7165,7 @@
     },
     "node_modules/argparse": {
       "version": "1.0.10",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -7242,7 +7267,7 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -7577,7 +7602,7 @@
     },
     "node_modules/body-parser": {
       "version": "1.20.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -7600,7 +7625,7 @@
     },
     "node_modules/body-parser/node_modules/bytes": {
       "version": "3.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7608,7 +7633,7 @@
     },
     "node_modules/body-parser/node_modules/debug": {
       "version": "2.6.9",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -7616,7 +7641,7 @@
     },
     "node_modules/body-parser/node_modules/depd": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7624,7 +7649,7 @@
     },
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/bonjour-service": {
@@ -7736,7 +7761,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -7844,7 +7869,7 @@
     },
     "node_modules/bytes": {
       "version": "3.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7922,7 +7947,7 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -7980,7 +8005,7 @@
     },
     "node_modules/cardinal": {
       "version": "2.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansicolors": "~0.3.2",
@@ -8041,7 +8066,7 @@
     },
     "node_modules/chownr": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -8101,7 +8126,7 @@
     },
     "node_modules/cli-boxes": {
       "version": "2.2.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8258,7 +8283,7 @@
     },
     "node_modules/colorette": {
       "version": "2.0.19",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorspace": {
@@ -8271,7 +8296,7 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -8299,7 +8324,7 @@
     },
     "node_modules/compressible": {
       "version": "2.0.18",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": ">= 1.43.0 < 2"
@@ -8310,7 +8335,7 @@
     },
     "node_modules/compression": {
       "version": "1.7.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.5",
@@ -8327,7 +8352,7 @@
     },
     "node_modules/compression/node_modules/debug": {
       "version": "2.6.9",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -8335,22 +8360,22 @@
     },
     "node_modules/compression/node_modules/ms": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/compression/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/configstore": {
       "version": "5.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "dot-prop": "^5.2.0",
@@ -8366,7 +8391,7 @@
     },
     "node_modules/configstore/node_modules/write-file-atomic": {
       "version": "3.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -8396,7 +8421,7 @@
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
@@ -8407,7 +8432,7 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -8419,7 +8444,7 @@
     },
     "node_modules/cookie": {
       "version": "0.5.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -8427,7 +8452,7 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/copy-anything": {
@@ -8628,7 +8653,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -8641,7 +8666,7 @@
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9357,7 +9382,7 @@
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
@@ -9365,7 +9390,7 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/deepmerge": {
@@ -9427,7 +9452,7 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -9455,7 +9480,7 @@
     },
     "node_modules/destroy": {
       "version": "1.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8",
@@ -9596,7 +9621,7 @@
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-obj": "^2.0.0"
@@ -9620,7 +9645,7 @@
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ejs": {
@@ -9670,7 +9695,7 @@
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -9697,7 +9722,7 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -9920,7 +9945,7 @@
     },
     "node_modules/escape-goat": {
       "version": "2.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9928,7 +9953,7 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -10365,7 +10390,7 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -10563,7 +10588,7 @@
     },
     "node_modules/espree": {
       "version": "9.4.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.8.0",
@@ -10579,7 +10604,7 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -10621,7 +10646,7 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -10629,7 +10654,7 @@
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -10700,7 +10725,7 @@
     },
     "node_modules/express": {
       "version": "4.18.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -10741,12 +10766,12 @@
     },
     "node_modules/express/node_modules/array-flatten": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -10754,7 +10779,7 @@
     },
     "node_modules/express/node_modules/depd": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -10762,7 +10787,7 @@
     },
     "node_modules/express/node_modules/ms": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/external-editor": {
@@ -10813,12 +10838,12 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fastest-levenshtein": {
@@ -10922,7 +10947,7 @@
     },
     "node_modules/finalhandler": {
       "version": "1.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -10939,7 +10964,7 @@
     },
     "node_modules/finalhandler/node_modules/debug": {
       "version": "2.6.9",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -10947,7 +10972,7 @@
     },
     "node_modules/finalhandler/node_modules/ms": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/find-cache-dir": {
@@ -18688,7 +18713,7 @@
     },
     "node_modules/form-data": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -18701,7 +18726,7 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -18725,7 +18750,7 @@
     },
     "node_modules/fresh": {
       "version": "0.5.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -18765,7 +18790,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/function.prototype.name": {
@@ -18833,7 +18858,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -19099,7 +19124,7 @@
     },
     "node_modules/has": {
       "version": "1.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1"
@@ -19147,7 +19172,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -19177,7 +19202,7 @@
     },
     "node_modules/has-yarn": {
       "version": "2.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -19311,7 +19336,7 @@
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
@@ -19326,7 +19351,7 @@
     },
     "node_modules/http-errors/node_modules/depd": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -19401,7 +19426,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -19587,7 +19612,7 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -19812,7 +19837,7 @@
     },
     "node_modules/ip": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ipaddr.js": {
@@ -19906,7 +19931,7 @@
     },
     "node_modules/is-ci": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ci-info": "^2.0.0"
@@ -19917,7 +19942,7 @@
     },
     "node_modules/is-ci/node_modules/ci-info": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-core-module": {
@@ -20067,7 +20092,7 @@
     },
     "node_modules/is-obj": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20075,7 +20100,7 @@
     },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -20194,7 +20219,7 @@
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-unicode-supported": {
@@ -20255,7 +20280,7 @@
     },
     "node_modules/is-yarn-global": {
       "version": "0.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isarray": {
@@ -20265,7 +20290,7 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -22276,7 +22301,7 @@
     },
     "node_modules/leven": {
       "version": "3.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -22492,7 +22517,7 @@
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^6.0.0"
@@ -22506,7 +22531,7 @@
     },
     "node_modules/make-dir/node_modules/semver": {
       "version": "6.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -22697,7 +22722,7 @@
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -22793,7 +22818,7 @@
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge-stream": {
@@ -22811,7 +22836,7 @@
     },
     "node_modules/methods": {
       "version": "1.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -22831,7 +22856,7 @@
     },
     "node_modules/mime": {
       "version": "1.6.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mime": "cli.js"
@@ -22842,7 +22867,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -22850,7 +22875,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -22908,7 +22933,7 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -22919,7 +22944,7 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -22940,7 +22965,7 @@
     },
     "node_modules/minipass": {
       "version": "4.2.1",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=8"
@@ -23113,7 +23138,7 @@
     },
     "node_modules/minizlib": {
       "version": "2.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^3.0.0",
@@ -23125,7 +23150,7 @@
     },
     "node_modules/minizlib/node_modules/minipass": {
       "version": "3.3.6",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -23136,7 +23161,7 @@
     },
     "node_modules/minizlib/node_modules/yallist": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/moment": {
@@ -23168,9 +23193,15 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "dev": true,
-      "license": "MIT",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -23236,7 +23267,7 @@
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -23388,7 +23419,7 @@
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-addon-api": {
@@ -23433,7 +23464,7 @@
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
-      "devOptional": true,
+      "dev": true,
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -23730,7 +23761,7 @@
     },
     "node_modules/object-inspect": {
       "version": "1.12.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -23821,7 +23852,7 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -23832,7 +23863,7 @@
     },
     "node_modules/on-headers": {
       "version": "1.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -24000,7 +24031,7 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -24247,7 +24278,7 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -24347,7 +24378,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -24355,7 +24386,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -24368,7 +24399,7 @@
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-type": {
@@ -24444,8 +24475,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.21",
-      "dev": true,
+      "version": "8.4.29",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.29.tgz",
+      "integrity": "sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==",
       "funding": [
         {
           "type": "opencollective",
@@ -24454,11 +24486,14 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -24601,11 +24636,12 @@
       }
     },
     "node_modules/postcss-sorting": {
-      "version": "7.0.1",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-8.0.2.tgz",
+      "integrity": "sha512-M9dkSrmU00t/jK7rF6BZSZauA5MAaBW4i5EnJXspMwt4iqTh/L9j6fgMnbElEOfyRyfLfVbIHj/R52zHzAPe1Q==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
-        "postcss": "^8.3.9"
+        "postcss": "^8.4.20"
       }
     },
     "node_modules/postcss-value-parser": {
@@ -24700,12 +24736,12 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -24766,7 +24802,7 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -24778,7 +24814,7 @@
     },
     "node_modules/proxy-addr/node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -24786,7 +24822,7 @@
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/prr": {
@@ -24797,12 +24833,12 @@
     },
     "node_modules/psl": {
       "version": "1.9.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -24818,7 +24854,7 @@
     },
     "node_modules/pupa": {
       "version": "2.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-goat": "^2.0.0"
@@ -24829,7 +24865,7 @@
     },
     "node_modules/qs": {
       "version": "6.11.0",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.4"
@@ -24883,7 +24919,7 @@
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -24891,7 +24927,7 @@
     },
     "node_modules/raw-body": {
       "version": "2.5.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -24905,7 +24941,7 @@
     },
     "node_modules/raw-body/node_modules/bytes": {
       "version": "3.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -24913,7 +24949,7 @@
     },
     "node_modules/rc": {
       "version": "1.2.8",
-      "devOptional": true,
+      "dev": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "dependencies": {
         "deep-extend": "^0.6.0",
@@ -24927,12 +24963,12 @@
     },
     "node_modules/rc/node_modules/ini": {
       "version": "1.3.8",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/rc/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -25091,7 +25127,7 @@
     },
     "node_modules/redeyed": {
       "version": "2.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esprima": "~4.0.0"
@@ -25191,7 +25227,7 @@
     },
     "node_modules/registry-url": {
       "version": "5.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "rc": "^1.2.8"
@@ -25362,7 +25398,7 @@
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -25376,7 +25412,7 @@
     },
     "node_modules/rimraf/node_modules/glob": {
       "version": "7.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -25615,7 +25651,7 @@
     },
     "node_modules/semver-diff": {
       "version": "3.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^6.3.0"
@@ -25626,7 +25662,7 @@
     },
     "node_modules/semver-diff/node_modules/semver": {
       "version": "6.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -25648,7 +25684,7 @@
     },
     "node_modules/send": {
       "version": "0.18.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -25671,7 +25707,7 @@
     },
     "node_modules/send/node_modules/debug": {
       "version": "2.6.9",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -25679,12 +25715,12 @@
     },
     "node_modules/send/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/send/node_modules/depd": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -25692,7 +25728,7 @@
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/serialize-javascript": {
@@ -25774,7 +25810,7 @@
     },
     "node_modules/serve-static": {
       "version": "1.15.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "~1.0.2",
@@ -25793,7 +25829,7 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/shallow-clone": {
@@ -25809,7 +25845,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -25820,7 +25856,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -25828,7 +25864,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
@@ -25979,7 +26015,7 @@
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
@@ -25999,7 +26035,7 @@
     },
     "node_modules/socks": {
       "version": "2.7.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ip": "^2.0.0",
@@ -26032,7 +26068,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -26146,7 +26181,7 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/ssri": {
@@ -26188,7 +26223,7 @@
     },
     "node_modules/statuses": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -26309,7 +26344,7 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -26383,80 +26418,49 @@
       }
     },
     "node_modules/stylelint-config-prettier-scss": {
-      "version": "0.0.1",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-prettier-scss/-/stylelint-config-prettier-scss-1.0.0.tgz",
+      "integrity": "sha512-Gr2qLiyvJGKeDk0E/+awNTrZB/UtNVPLqCDOr07na/sLekZwm26Br6yYIeBYz3ulsEcQgs5j+2IIMXCC+wsaQA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "stylelint-config-prettier": ">=9.0.3"
-      },
       "bin": {
         "stylelint-config-prettier-scss": "bin/check.js",
         "stylelint-config-prettier-scss-check": "bin/check.js"
       },
       "engines": {
-        "node": ">= 12"
+        "node": "14.* || 16.* || >= 18"
       },
       "peerDependencies": {
-        "stylelint": ">=11.0.0"
-      }
-    },
-    "node_modules/stylelint-config-prettier-scss/node_modules/stylelint-config-prettier": {
-      "version": "9.0.5",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "stylelint-config-prettier": "bin/check.js",
-        "stylelint-config-prettier-check": "bin/check.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      },
-      "peerDependencies": {
-        "stylelint": ">= 11.x < 15"
+        "stylelint": ">=15.0.0"
       }
     },
     "node_modules/stylelint-config-sass-guidelines": {
-      "version": "9.0.1",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-sass-guidelines/-/stylelint-config-sass-guidelines-10.0.0.tgz",
+      "integrity": "sha512-+Rr2Dd4b72CWA4qoj1Kk+y449nP/WJsrD0nzQAWkmPPIuyVcy2GMIcfNr0Z8JJOLjRvtlkKxa49FCNXMePBikQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "postcss-scss": "^4.0.2",
-        "stylelint-order": "^5.0.0",
-        "stylelint-scss": "^4.0.0"
+        "postcss-scss": "^4.0.6",
+        "stylelint-scss": "^4.4.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": "^14.13.1 || >=16.13.0 || >=18.0.0"
       },
       "peerDependencies": {
-        "postcss": "^8.3.3",
-        "stylelint": "^14.0.1"
+        "postcss": "^8.4.21",
+        "stylelint": "^15.2.0"
       }
     },
-    "node_modules/stylelint-config-sass-guidelines/node_modules/stylelint-order": {
-      "version": "5.0.0",
+    "node_modules/stylelint-order": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-6.0.3.tgz",
+      "integrity": "sha512-1j1lOb4EU/6w49qZeT2SQVJXm0Ht+Qnq9GMfUa3pMwoyojIWfuA+JUDmoR97Bht1RLn4ei0xtLGy87M7d29B1w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "postcss": "^8.3.11",
-        "postcss-sorting": "^7.0.1"
+        "postcss": "^8.4.21",
+        "postcss-sorting": "^8.0.2"
       },
       "peerDependencies": {
-        "stylelint": "^14.0.0"
-      }
-    },
-    "node_modules/stylelint-prettier": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "prettier": ">=2.0.0",
-        "stylelint": ">=14.0.0"
+        "stylelint": "^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/stylelint-scss": {
@@ -26536,7 +26540,7 @@
     },
     "node_modules/supports-hyperlinks": {
       "version": "2.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0",
@@ -26548,7 +26552,7 @@
     },
     "node_modules/supports-hyperlinks/node_modules/has-flag": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -26556,7 +26560,7 @@
     },
     "node_modules/supports-hyperlinks/node_modules/supports-color": {
       "version": "7.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -26618,7 +26622,7 @@
     },
     "node_modules/tar": {
       "version": "6.1.13",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
@@ -26634,7 +26638,7 @@
     },
     "node_modules/tar/node_modules/fs-minipass": {
       "version": "2.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -26645,7 +26649,7 @@
     },
     "node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
       "version": "3.3.6",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -26656,7 +26660,7 @@
     },
     "node_modules/tar/node_modules/mkdirp": {
       "version": "1.0.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
@@ -26667,7 +26671,7 @@
     },
     "node_modules/tar/node_modules/yallist": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/term-size": {
@@ -26879,7 +26883,7 @@
     },
     "node_modules/tmp": {
       "version": "0.2.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "rimraf": "^3.0.0"
@@ -26920,7 +26924,7 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -27216,7 +27220,7 @@
     },
     "node_modules/type-is": {
       "version": "1.6.18",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
@@ -27246,7 +27250,7 @@
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
@@ -27337,7 +27341,7 @@
     },
     "node_modules/unique-string": {
       "version": "2.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "crypto-random-string": "^2.0.0"
@@ -27355,7 +27359,7 @@
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -27513,7 +27517,7 @@
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
@@ -27521,7 +27525,7 @@
     },
     "node_modules/uuid": {
       "version": "8.3.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -27574,7 +27578,7 @@
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -27958,7 +27962,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -28028,7 +28032,7 @@
     },
     "node_modules/widest-line": {
       "version": "3.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "string-width": "^4.0.0"
@@ -28076,7 +28080,7 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -28162,7 +28166,7 @@
     },
     "node_modules/xdg-basedir": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -28199,7 +28203,7 @@
     },
     "node_modules/yaml": {
       "version": "1.10.2",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 6"
@@ -28245,7 +28249,7 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lodash": "^4.17.21",
     "lz-string": "^1.4.4",
     "moment": "^2.29.4",
+    "postcss": "^8.4.29",
     "rxjs": "^7.5.6",
     "tslib": "^2.4.0",
     "zone.js": "~0.11.4"
@@ -82,20 +83,12 @@
     "jest-preset-angular": "^12.2.0",
     "prettier": "2.8.0",
     "stylelint": "^15.2.0",
-    "stylelint-config-prettier-scss": "0.0.1",
-    "stylelint-config-sass-guidelines": "^9.0.1",
-    "stylelint-prettier": "^3.0.0",
+    "stylelint-config-prettier-scss": "^1.0.0",
+    "stylelint-config-sass-guidelines": "^10.0.0",
+    "stylelint-order": "^6.0.3",
     "ts-mockito": "^2.6.1",
     "ts-node": "~8.1.0",
     "typescript": "~4.9.5"
-  },
-  "overrides": {
-    "stylelint-config-sass-guidelines": {
-      "stylelint": "^15.2.0"
-    },
-    "stylelint-config-prettier": {
-      "stylelint": "^15.2.0"
-    }
   },
   "browserslist": [
     "defaults",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "lodash": "^4.17.21",
     "lz-string": "^1.4.4",
     "moment": "^2.29.4",
-    "postcss": "^8.4.29",
     "rxjs": "^7.5.6",
     "tslib": "^2.4.0",
     "zone.js": "~0.11.4"
@@ -81,6 +80,7 @@
     "jest": "^28.1.3",
     "jest-junit": "^14.0.1",
     "jest-preset-angular": "^12.2.0",
+    "postcss": "^8.4.29",
     "prettier": "2.8.0",
     "stylelint": "^15.2.0",
     "stylelint-config-prettier-scss": "^1.0.0",


### PR DESCRIPTION
* update prettier and sass guidelines for stylelint  v15
* remove deprecated stylelint-prettier dependency
* added new stylint-order dependency
* added postcss peer dependency

relates to https://github.com/globe-swiss/phaenonet-maintenance/issues/7