### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/actions/angular-http-server-action/action.yml
+++ b/.github/actions/angular-http-server-action/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@v3.6.0
+    - uses: actions/setup-node@v4.0.1
       with:
         node-version: ${{ env.NODE_VERSION }}
     - run: npx angular-http-server --path ${{ inputs.path }} --p ${{ inputs.port }} &

--- a/.github/actions/deploy-hosting-action/action.yml
+++ b/.github/actions/deploy-hosting-action/action.yml
@@ -26,7 +26,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@v3.6.0
+    - uses: actions/setup-node@v4.0.1
       with:
         node-version: ${{ env.NODE_VERSION }}
     - id: auth

--- a/.github/actions/download-zip-artifact/action.yml
+++ b/.github/actions/download-zip-artifact/action.yml
@@ -11,11 +11,11 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@v3.6.0
+    - uses: actions/setup-node@v4.0.1
       with:
         node-version: ${{ env.NODE_VERSION }}
     - name: Download Build Artifact
-      uses: actions/download-artifact@v3.0.2
+      uses: actions/download-artifact@v4.1.1
       with:
         name: ${{ inputs.name }}
         path: ${{ runner.temp }}/

--- a/.github/actions/upload-zip-artifact/action.yml
+++ b/.github/actions/upload-zip-artifact/action.yml
@@ -23,7 +23,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@v3.6.0
+    - uses: actions/setup-node@v4.0.1
       with:
         node-version: ${{ env.NODE_VERSION }}
     - name: zip contents
@@ -31,8 +31,8 @@ runs:
       with:
         pathSource: ${{ inputs.path }}
         pathTarget: ${{ runner.temp }}/${{ inputs.name }}.zip
-    - name: Upload E2E-Test Artifact
-      uses: actions/upload-artifact@v3.1.2
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4.3.0
       with:
         name: ${{ inputs.name }}
         path: ${{ runner.temp }}/${{ inputs.name }}.zip

--- a/.github/workflows/channel.yml
+++ b/.github/workflows/channel.yml
@@ -32,8 +32,8 @@ jobs:
       checks: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.5.2
-      - uses: actions/setup-node@v3.6.0
+        uses: actions/checkout@v4.1.1
+      - uses: actions/setup-node@v4.0.1
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install Dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,8 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.5.2
-      - uses: actions/setup-node@v3.6.0
+        uses: actions/checkout@v4.1.1
+      - uses: actions/setup-node@v4.0.1
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install Dependencies
@@ -63,12 +63,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v4.1.1
       - name: Download Artifact
         uses: ./.github/actions/download-zip-artifact
         with:
           name: ${{ env.PROJECT }}
-      - uses: actions/setup-node@v3.6.0
+      - uses: actions/setup-node@v4.0.1
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install sentry-cli
@@ -96,9 +96,9 @@ jobs:
     environment: ${{ github.event.inputs.project || 'phaenonet-test' }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v4.1.1
       - name: Checkout rules
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v4.1.1
         with:
           repository: globe-swiss/phaenonet-client-security
           path: security
@@ -110,14 +110,14 @@ jobs:
       - name: Remove source maps (prod)
         run: rm ./dist/**/*.map
         if: ${{ env.PROJECT == 'phaenonet' }}
-      - uses: actions/setup-node@v3.6.0
+      - uses: actions/setup-node@v4.0.1
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: install firebase-tools
         run: npm i --no-save firebase-tools
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v1.1.1
+        uses: google-github-actions/auth@v2.1.0
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -143,8 +143,8 @@ jobs:
     if: ${{ github.event.inputs.project == 'phaenonet' }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.5.2
-      - uses: actions/setup-node@v3.6.0
+        uses: actions/checkout@v4.1.1
+      - uses: actions/setup-node@v4.0.1
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: build & upload docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.5.2
-      - uses: actions/setup-node@v3.6.0
+        uses: actions/checkout@v4.1.1
+      - uses: actions/setup-node@v4.0.1
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Check cache (node modules)
@@ -42,8 +42,8 @@ jobs:
     needs: cache-deps
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.5.2
-      - uses: actions/setup-node@v3.6.0
+        uses: actions/checkout@v4.1.1
+      - uses: actions/setup-node@v4.0.1
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Restore cache (node modules)
@@ -77,7 +77,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v4.1.1
       - name: Download Build Artifact
         uses: ./.github/actions/download-zip-artifact
         with:
@@ -102,8 +102,8 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.5.2
-      - uses: actions/setup-node@v3.6.0
+        uses: actions/checkout@v4.1.1
+      - uses: actions/setup-node@v4.0.1
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Download Build Artifact
@@ -145,8 +145,8 @@ jobs:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.5.2
-      - uses: actions/setup-node@v3.6.0
+        uses: actions/checkout@v4.1.1
+      - uses: actions/setup-node@v4.0.1
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Restore cache (node modules)
@@ -156,7 +156,7 @@ jobs:
           key: module-${{ env.NODE_VERSION }}-${{ env.CACHE_SEQ }}-${{ hashFiles('package-lock.json') }}
       - name: install codeceptjs deps
         run: npm --prefix e2e ci
-      - uses: reviewdog/action-setup@v1
+      - uses: reviewdog/action-setup@v1.2.0
         with:
           reviewdog_version: ${{ env.REVIEWDOG_VERSION }}
       - name: check map icon completeness

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 env:
   NODE_VERSION: '18'
   CACHE_SEQ: 1
-  REVIEWDOG_VERSION: 'v0.14.2'
+  REVIEWDOG_VERSION: 'v0.17.0'
 
 jobs:
   cache-deps:

--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.5.2
+      - uses: actions/checkout@v4.1.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.4
+        uses: saadmk11/github-actions-version-updater@v0.8.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[google-github-actions/auth](https://github.com/google-github-actions/auth)** published a new release **[v2.1.0](https://github.com/google-github-actions/auth/releases/tag/v2.1.0)** on 2024-01-23T02:09:59Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.1)** on 2023-08-13T13:53:59Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.1](https://github.com/actions/setup-node/releases/tag/v4.0.1)** on 2023-12-18T11:05:34Z
* **[reviewdog/action-setup](https://github.com/reviewdog/action-setup)** published a new release **[v1.2.0](https://github.com/reviewdog/action-setup/releases/tag/v1.2.0)** on 2024-01-22T12:57:41Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
