### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/channel.yml
+++ b/.github/workflows/channel.yml
@@ -33,11 +33,11 @@ jobs:
       checks: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.1.1
-      - uses: pnpm/action-setup@v3
+        uses: actions/checkout@v4.1.7
+      - uses: pnpm/action-setup@v4.0.0
         with:
           version: 8
-      - uses: actions/setup-node@v4.0.1
+      - uses: actions/setup-node@v4.0.2
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,11 +35,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.1.1
-      - uses: pnpm/action-setup@v3
+        uses: actions/checkout@v4.1.7
+      - uses: pnpm/action-setup@v4.0.0
         with:
           version: 8
-      - uses: actions/setup-node@v4.0.1
+      - uses: actions/setup-node@v4.0.2
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -68,15 +68,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.7
       - name: Download Artifact
         uses: ./.github/actions/download-zip-artifact
         with:
           name: ${{ env.PROJECT }}
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4.0.0
         with:
           version: 8
-      - uses: actions/setup-node@v4.0.1
+      - uses: actions/setup-node@v4.0.2
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -104,9 +104,9 @@ jobs:
     environment: ${{ github.event.inputs.project || 'phaenonet-test' }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.7
       - name: Checkout rules
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.7
         with:
           repository: globe-swiss/phaenonet-client-security
           path: security
@@ -118,17 +118,17 @@ jobs:
       - name: Remove source maps (prod)
         run: rm ./dist/**/*.map
         if: ${{ env.PROJECT == 'phaenonet' }}
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4.0.0
         with:
           version: 8
-      - uses: actions/setup-node@v4.0.1
+      - uses: actions/setup-node@v4.0.2
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
       - run: pnpm install
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2.1.0
+        uses: google-github-actions/auth@v2.1.3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -154,11 +154,11 @@ jobs:
     if: ${{ github.event.inputs.project == 'phaenonet' }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.1.1
-      - uses: pnpm/action-setup@v3
+        uses: actions/checkout@v4.1.7
+      - uses: pnpm/action-setup@v4.0.0
         with:
           version: 8
-      - uses: actions/setup-node@v4.0.1
+      - uses: actions/setup-node@v4.0.2
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,17 +17,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.1.1
-      - uses: pnpm/action-setup@v3
+        uses: actions/checkout@v4.1.7
+      - uses: pnpm/action-setup@v4.0.0
         with:
           version: 8
-      - uses: actions/setup-node@v4.0.1
+      - uses: actions/setup-node@v4.0.2
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
       - run: pnpm install
       - name: Set API info
-        uses: suisei-cn/actions-download-file@v1.4.0
+        uses: suisei-cn/actions-download-file@v1.6.0
         with:
           url: ${{ secrets.FIREBASE_TEST_API_URL }}
           target: ./src/local/
@@ -52,7 +52,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.7
       - name: Download Build Artifact
         uses: ./.github/actions/download-zip-artifact
         with:
@@ -78,11 +78,11 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.1.1
-      - uses: pnpm/action-setup@v3
+        uses: actions/checkout@v4.1.7
+      - uses: pnpm/action-setup@v4.0.0
         with:
           version: 8
-      - uses: actions/setup-node@v4.0.1
+      - uses: actions/setup-node@v4.0.2
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -125,16 +125,16 @@ jobs:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.1.1
-      - uses: pnpm/action-setup@v3
+        uses: actions/checkout@v4.1.7
+      - uses: pnpm/action-setup@v4.0.0
         with:
           version: 8
-      - uses: actions/setup-node@v4.0.1
+      - uses: actions/setup-node@v4.0.2
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
       - run: pnpm -r install
-      - uses: reviewdog/action-setup@v1.2.0
+      - uses: reviewdog/action-setup@v1.3.0
         with:
           reviewdog_version: ${{ env.REVIEWDOG_VERSION }}
       - name: check map icon completeness

--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.7
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}

--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -1,6 +1,9 @@
 name: GitHub Actions Version Updater
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 5 * * 5'
 
 jobs:
   build:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
* **[pnpm/action-setup](https://github.com/pnpm/action-setup)** published a new release **[v4.0.0](https://github.com/pnpm/action-setup/releases/tag/v4.0.0)** on 2024-05-07T13:19:01Z
* **[google-github-actions/auth](https://github.com/google-github-actions/auth)** published a new release **[v2.1.3](https://github.com/google-github-actions/auth/releases/tag/v2.1.3)** on 2024-05-14T17:58:05Z
* **[reviewdog/action-setup](https://github.com/reviewdog/action-setup)** published a new release **[v1.3.0](https://github.com/reviewdog/action-setup/releases/tag/v1.3.0)** on 2024-03-12T15:18:50Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.2](https://github.com/actions/setup-node/releases/tag/v4.0.2)** on 2024-02-07T04:51:19Z
* **[suisei-cn/actions-download-file](https://github.com/suisei-cn/actions-download-file)** published a new release **[v1.6.0](https://github.com/suisei-cn/actions-download-file/releases/tag/v1.6.0)** on 2024-01-27T02:31:59Z
