### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/channel.yml
+++ b/.github/workflows/channel.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: pnpm/action-setup@v4.0.0
         with:
           version: 8
-      - uses: actions/setup-node@v4.0.2
+      - uses: actions/setup-node@v4.0.3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: pnpm/action-setup@v4.0.0
         with:
           version: 8
-      - uses: actions/setup-node@v4.0.2
+      - uses: actions/setup-node@v4.0.3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -76,7 +76,7 @@ jobs:
       - uses: pnpm/action-setup@v4.0.0
         with:
           version: 8
-      - uses: actions/setup-node@v4.0.2
+      - uses: actions/setup-node@v4.0.3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -121,7 +121,7 @@ jobs:
       - uses: pnpm/action-setup@v4.0.0
         with:
           version: 8
-      - uses: actions/setup-node@v4.0.2
+      - uses: actions/setup-node@v4.0.3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -158,7 +158,7 @@ jobs:
       - uses: pnpm/action-setup@v4.0.0
         with:
           version: 8
-      - uses: actions/setup-node@v4.0.2
+      - uses: actions/setup-node@v4.0.3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: pnpm/action-setup@v4.0.0
         with:
           version: 8
-      - uses: actions/setup-node@v4.0.2
+      - uses: actions/setup-node@v4.0.3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -82,7 +82,7 @@ jobs:
       - uses: pnpm/action-setup@v4.0.0
         with:
           version: 8
-      - uses: actions/setup-node@v4.0.2
+      - uses: actions/setup-node@v4.0.3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -129,7 +129,7 @@ jobs:
       - uses: pnpm/action-setup@v4.0.0
         with:
           version: 8
-      - uses: actions/setup-node@v4.0.2
+      - uses: actions/setup-node@v4.0.3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.0.3](https://github.com/actions/setup-node/releases/tag/v4.0.3)** on 2024-07-09T14:22:34Z
