### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,7 +122,7 @@ jobs:
       - run: pnpm install
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2.1.3
+        uses: google-github-actions/auth@v2.1.4
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,7 +152,7 @@ jobs:
       - name: check style
         run: pnpm exec prettier -c "."
         if: always()
-      - uses: EPMatt/reviewdog-action-prettier@v1
+      - uses: EPMatt/reviewdog-action-prettier@v1.2.0
         with:
           reporter: github-pr-check
           level: error

--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.7
       - uses: pnpm/action-setup@v4.0.0
         with:
           version: 8
@@ -47,7 +47,7 @@ jobs:
           git diff --exit-code || echo "changes=true" >> $GITHUB_OUTPUT
       - name: Create Pull Request
         if: ${{ steps.git-check.outputs.changes == 'true' }}
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6.1.0
         with:
           commit-message: 'Update packages'
           title: '[Automated] Update Packages'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[EPMatt/reviewdog-action-prettier](https://github.com/EPMatt/reviewdog-action-prettier)** published a new release **[v1.2.0](https://github.com/EPMatt/reviewdog-action-prettier/releases/tag/v1.2.0)** on 2023-07-02T20:32:45Z
* **[google-github-actions/auth](https://github.com/google-github-actions/auth)** published a new release **[v2.1.4](https://github.com/google-github-actions/auth/releases/tag/v2.1.4)** on 2024-08-06T01:27:23Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v6.1.0](https://github.com/peter-evans/create-pull-request/releases/tag/v6.1.0)** on 2024-06-18T16:54:59Z
