### PR TITLE
[Automated] Update GitHub Action Versions [no ci]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,7 @@ jobs:
         uses: codecov/codecov-action@v5.0.0
         with:
           use_oidc: true
-          file: ./e2e/output/coverage-reports/codecov.json
+          files: ./e2e/output/coverage-reports/codecov.json
           flags: e2e
         if: always() && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
   checks:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
           expires: 30d
         if: always() && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
       - name: Codecov
-        uses: codecov/codecov-action@v4.6.0
+        uses: codecov/codecov-action@v5.0.0
         with:
           use_oidc: true
           file: ./e2e/output/coverage-reports/codecov.json


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.0.0](https://github.com/codecov/codecov-action/releases/tag/v5.0.0)** on 2024-11-14T16:40:05Z
