### PR TITLE
[Automated] Update GitHub Action Versions [no ci]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
           expires: 30d
         if: always() && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
       - name: Codecov
-        uses: codecov/codecov-action@v5.1.2
+        uses: codecov/codecov-action@v5.3.0
         with:
           use_oidc: true
           files: ./e2e/output/coverage-reports/codecov.json


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.3.0](https://github.com/codecov/codecov-action/releases/tag/v5.3.0)** on 2025-01-23T19:11:50Z
