### PR TITLE
[Automated] Update GitHub Action Versions [no ci]

### DIFF
--- a/.github/workflows/channel.yml
+++ b/.github/workflows/channel.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4.2.2
       - name: Set environment variables
         run: cat .env >> $GITHUB_ENV
-      - uses: pnpm/action-setup@v4.0.0
+      - uses: pnpm/action-setup@v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v4.2.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4.2.2
       - name: Set environment variables
         run: cat .env >> $GITHUB_ENV
-      - uses: pnpm/action-setup@v4.0.0
+      - uses: pnpm/action-setup@v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v4.2.0
@@ -69,7 +69,7 @@ jobs:
         uses: ./.github/actions/download-zip-artifact
         with:
           name: ${{ env.PROJECT }}
-      - uses: pnpm/action-setup@v4.0.0
+      - uses: pnpm/action-setup@v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v4.2.0
@@ -116,7 +116,7 @@ jobs:
       - name: Remove source maps (prod)
         run: rm ./dist/**/*.map
         if: ${{ env.PROJECT == 'phaenonet' }}
-      - uses: pnpm/action-setup@v4.0.0
+      - uses: pnpm/action-setup@v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v4.2.0
@@ -126,7 +126,7 @@ jobs:
       - run: pnpm install
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2.1.7
+        uses: google-github-actions/auth@v2.1.8
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
@@ -155,7 +155,7 @@ jobs:
         uses: actions/checkout@v4.2.2
       - name: Set environment variables
         run: cat .env >> $GITHUB_ENV
-      - uses: pnpm/action-setup@v4.0.0
+      - uses: pnpm/action-setup@v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v4.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4.2.2
       - name: Set environment variables
         run: cat .env >> $GITHUB_ENV
-      - uses: pnpm/action-setup@v4.0.0
+      - uses: pnpm/action-setup@v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v4.2.0
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v4.2.2
       - name: Set environment variables
         run: cat .env >> $GITHUB_ENV
-      - uses: pnpm/action-setup@v4.0.0
+      - uses: pnpm/action-setup@v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v4.2.0
@@ -134,7 +134,7 @@ jobs:
         uses: actions/checkout@v4.2.2
       - name: Set environment variables
         run: cat .env >> $GITHUB_ENV
-      - uses: pnpm/action-setup@v4.0.0
+      - uses: pnpm/action-setup@v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v4.2.0

--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4.2.2
       - name: Set environment variables
         run: cat .env >> $GITHUB_ENV
-      - uses: pnpm/action-setup@v4.0.0
+      - uses: pnpm/action-setup@v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v4.2.0


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[google-github-actions/auth](https://github.com/google-github-actions/auth)** published a new release **[v2.1.8](https://github.com/google-github-actions/auth/releases/tag/v2.1.8)** on 2025-02-01T14:17:24Z
* **[pnpm/action-setup](https://github.com/pnpm/action-setup)** published a new release **[v4.1.0](https://github.com/pnpm/action-setup/releases/tag/v4.1.0)** on 2025-02-06T21:33:00Z
