### PR TITLE
[Automated] Update GitHub Action Versions [no ci]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,7 @@ jobs:
           expires: 30d
         if: always() && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
       - name: Codecov
-        uses: codecov/codecov-action@v5.3.1
+        uses: codecov/codecov-action@v5.4.0
         with:
           use_oidc: true
           files: ./e2e/output/coverage-reports/codecov.json

--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -45,7 +45,7 @@ jobs:
           git diff --exit-code || echo "changes=true" >> $GITHUB_OUTPUT
       - name: Create Pull Request
         if: ${{ steps.git-check.outputs.changes == 'true' }}
-        uses: peter-evans/create-pull-request@v7.0.6
+        uses: peter-evans/create-pull-request@v7.0.8
         with:
           # required to trigger e2e-test workflow
           token: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.4.0](https://github.com/codecov/codecov-action/releases/tag/v5.4.0)** on 2025-02-26T23:41:16Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v7.0.8](https://github.com/peter-evans/create-pull-request/releases/tag/v7.0.8)** on 2025-03-04T10:35:28Z
