### PR TITLE
Potential fix for code scanning alert no. 6: Use of a known vulnerable action [no ci]

### DIFF
--- a/.github/actions/download-zip-artifact/action.yml
+++ b/.github/actions/download-zip-artifact/action.yml
@@ -15,7 +15,7 @@ runs:
       with:
         node-version: ${{ env.NODE_VERSION }}
     - name: Download Build Artifact
-      uses: actions/download-artifact@v4.1.1
+      uses: actions/download-artifact@v4.1.3
       with:
         name: ${{ inputs.name }}
         path: ${{ runner.temp }}/


### PR DESCRIPTION
Fix for [https://github.com/globe-swiss/phaenonet-client/security/code-scanning/6](https://github.com/globe-swiss/phaenonet-client/security/code-scanning/6)

To fix the problem, the `actions/download-artifact` action should be updated from version `v4.1.1` to the latest secure version, `v4.1.3`. This change ensures that the workflow no longer uses a version of the action with known vulnerabilities. The update should be made in the `.github/actions/download-zip-artifact/action.yml` file, specifically on line 18 where the vulnerable action is referenced.

