### PR TITLE
[Automated] Update GitHub Action Versions [no ci]

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
       tag: ${{ steps.new-tag.outputs.tag }}
       version: ${{ steps.new-tag.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
       - name: 'Get previous tag'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[WyriHaximus/github-action-get-previous-tag](https://github.com/WyriHaximus/github-action-get-previous-tag)** published a new release **[v1.4.0](https://github.com/WyriHaximus/github-action-get-previous-tag/releases/tag/v1.4.0)** on 2024-01-28T15:48:12Z
* **[WyriHaximus/github-action-next-semvers](https://github.com/WyriHaximus/github-action-next-semvers)** published a new release **[v1.2.1](https://github.com/WyriHaximus/github-action-next-semvers/releases/tag/v1.2.1)** on 2022-12-19T13:18:37Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
