### PR TITLE
[Automated] Update GitHub Action Versions [no ci]

### DIFF
--- a/.github/actions/deploy-hosting-action/action.yml
+++ b/.github/actions/deploy-hosting-action/action.yml
@@ -31,7 +31,7 @@ runs:
         node-version: 20 # match requirements of FirebaseExtended/action-hosting-deploy
     - id: auth
       name: Authenticate to Google Cloud
-      uses: google-github-actions/auth@v2.1.10
+      uses: google-github-actions/auth@v2.1.11
       with:
         workload_identity_provider: ${{ inputs.workload_identity_provider }}
         service_account: ${{ inputs.service_account }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,12 +46,12 @@ jobs:
           fetch-depth: 0
       - name: 'Get previous tag'
         id: previoustag
-        uses: 'WyriHaximus/github-action-get-previous-tag@v1'
+        uses: 'WyriHaximus/github-action-get-previous-tag@v1.4.0'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       - name: 'Get next versions'
         id: semvers
-        uses: 'WyriHaximus/github-action-next-semvers@v1'
+        uses: 'WyriHaximus/github-action-next-semvers@v1.2.1'
         with:
           version: ${{ steps.previoustag.outputs.tag }}
       - name: Set tag
@@ -175,7 +175,7 @@ jobs:
       - run: pnpm install
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2.1.10
+        uses: google-github-actions/auth@v2.1.11
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[WyriHaximus/github-action-get-previous-tag](https://github.com/WyriHaximus/github-action-get-previous-tag)** published a new release **[v1.4.0](https://github.com/WyriHaximus/github-action-get-previous-tag/releases/tag/v1.4.0)** on 2024-01-28T15:48:12Z
* **[WyriHaximus/github-action-next-semvers](https://github.com/WyriHaximus/github-action-next-semvers)** published a new release **[v1.2.1](https://github.com/WyriHaximus/github-action-next-semvers/releases/tag/v1.2.1)** on 2022-12-19T13:18:37Z
* **[google-github-actions/auth](https://github.com/google-github-actions/auth)** published a new release **[v2.1.11](https://github.com/google-github-actions/auth/releases/tag/v2.1.11)** on 2025-07-18T21:17:34Z
