### PR TITLE
[Automated] Update GitHub Action Versions [no ci]

### DIFF
--- a/.github/actions/deploy-hosting-action/action.yml
+++ b/.github/actions/deploy-hosting-action/action.yml
@@ -31,7 +31,7 @@ runs:
         node-version: 20 # match requirements of FirebaseExtended/action-hosting-deploy
     - id: auth
       name: Authenticate to Google Cloud
-      uses: google-github-actions/auth@v2.1.11
+      uses: google-github-actions/auth@v2.1.12
       with:
         workload_identity_provider: ${{ inputs.workload_identity_provider }}
         service_account: ${{ inputs.service_account }}

--- a/.github/actions/download-zip-artifact/action.yml
+++ b/.github/actions/download-zip-artifact/action.yml
@@ -18,7 +18,7 @@ runs:
       with:
         node-version: ${{ inputs.node_version }}
     - name: Download Build Artifact
-      uses: actions/download-artifact@v4.3.0
+      uses: actions/download-artifact@v5.0.0
       with:
         name: ${{ inputs.name }}
         path: ${{ runner.temp }}/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -175,7 +175,7 @@ jobs:
       - run: pnpm install
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2.1.11
+        uses: google-github-actions/auth@v2.1.12
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[google-github-actions/auth](https://github.com/google-github-actions/auth)** published a new release **[v2.1.12](https://github.com/google-github-actions/auth/releases/tag/v2.1.12)** on 2025-08-01T15:15:57Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v5.0.0](https://github.com/actions/download-artifact/releases/tag/v5.0.0)** on 2025-08-05T21:38:42Z
