### PR TITLE
[Automated] Update GitHub Action Versions [no ci]

### DIFF
--- a/.github/actions/deploy-hosting-action/action.yml
+++ b/.github/actions/deploy-hosting-action/action.yml
@@ -41,7 +41,7 @@ runs:
       run: |
         echo "SERVICE_ACCOUNT_KEY=$(cat "${{ steps.auth.outputs.credentials_file_path }}" | tr -d '\n')" >> $GITHUB_ENV
     - name: Deploy E2E-Test Report
-      uses: FirebaseExtended/action-hosting-deploy@v0.9.0
+      uses: FirebaseExtended/action-hosting-deploy@v0.10.0
       with:
         firebaseServiceAccount: '${{ env.SERVICE_ACCOUNT_KEY }}'
         repoToken: '${{ inputs.repo_token }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,7 @@ jobs:
           expires: 30d
         if: always() && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
       - name: Codecov
-        uses: codecov/codecov-action@v5.4.3
+        uses: codecov/codecov-action@v5.5.0
         with:
           use_oidc: true
           files: ./e2e/output/coverage-reports/codecov.json


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[FirebaseExtended/action-hosting-deploy](https://github.com/FirebaseExtended/action-hosting-deploy)** published a new release **[v0.10.0](https://github.com/FirebaseExtended/action-hosting-deploy/releases/tag/v0.10.0)** on 2025-08-18T17:12:51Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.5.0](https://github.com/codecov/codecov-action/releases/tag/v5.5.0)** on 2025-08-20T14:04:55Z
