### PR TITLE
[Automated] Update GitHub Action Versions [no ci]

### DIFF
--- a/.github/actions/deploy-hosting-action/action.yml
+++ b/.github/actions/deploy-hosting-action/action.yml
@@ -26,12 +26,12 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@v4.4.0
+    - uses: actions/setup-node@v5.0.0
       with:
         node-version: 20 # match requirements of FirebaseExtended/action-hosting-deploy
     - id: auth
       name: Authenticate to Google Cloud
-      uses: google-github-actions/auth@v2.1.12
+      uses: google-github-actions/auth@v3.0.0
       with:
         workload_identity_provider: ${{ inputs.workload_identity_provider }}
         service_account: ${{ inputs.service_account }}

--- a/.github/actions/download-zip-artifact/action.yml
+++ b/.github/actions/download-zip-artifact/action.yml
@@ -14,7 +14,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@v4.4.0
+    - uses: actions/setup-node@v5.0.0
       with:
         node-version: ${{ inputs.node_version }}
     - name: Download Build Artifact

--- a/.github/actions/upload-zip-artifact/action.yml
+++ b/.github/actions/upload-zip-artifact/action.yml
@@ -26,7 +26,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@v4.4.0
+    - uses: actions/setup-node@v5.0.0
       with:
         node-version: ${{ inputs.node_version }}
     - name: zip contents

--- a/.github/workflows/channel.yml
+++ b/.github/workflows/channel.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: pnpm/action-setup@v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: pnpm/action-setup@v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -120,7 +120,7 @@ jobs:
       - uses: pnpm/action-setup@v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -168,14 +168,14 @@ jobs:
       - uses: pnpm/action-setup@v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
       - run: pnpm install
       - id: auth
         name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2.1.12
+        uses: google-github-actions/auth@v3.0.0
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: pnpm/action-setup@v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -91,7 +91,7 @@ jobs:
       - uses: pnpm/action-setup@v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -131,7 +131,7 @@ jobs:
           expires: 30d
         if: always() && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
       - name: Codecov
-        uses: codecov/codecov-action@v5.5.0
+        uses: codecov/codecov-action@v5.5.1
         with:
           use_oidc: true
           files: ./e2e/output/coverage-reports/codecov.json
@@ -149,12 +149,12 @@ jobs:
       - uses: pnpm/action-setup@v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
       - run: pnpm -r install
-      - uses: reviewdog/action-setup@v1.3.2
+      - uses: reviewdog/action-setup@v1.4.0
         with:
           reviewdog_version: ${{ env.REVIEWDOG_VERSION }}
       - name: check map icon completeness

--- a/.github/workflows/version-updater.yml
+++ b/.github/workflows/version-updater.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: pnpm/action-setup@v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/setup-node@v5.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[google-github-actions/auth](https://github.com/google-github-actions/auth)** published a new release **[v3.0.0](https://github.com/google-github-actions/auth/releases/tag/v3.0.0)** on 2025-08-28T18:51:57Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v5.0.0](https://github.com/actions/setup-node/releases/tag/v5.0.0)** on 2025-09-04T02:52:29Z
* **[reviewdog/action-setup](https://github.com/reviewdog/action-setup)** published a new release **[v1.4.0](https://github.com/reviewdog/action-setup/releases/tag/v1.4.0)** on 2025-09-03T01:46:27Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.5.1](https://github.com/codecov/codecov-action/releases/tag/v5.5.1)** on 2025-09-04T14:36:56Z
