### PR TITLE
fix pnpm versions for renovate

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,9 +73,10 @@
   },
   "engines": {
     "node": "=22",
-    "pnpm": ">=3"
+    "pnpm": "10.24.0"
   },
   "name": "phaenonet",
+  "packageManager": "pnpm@10.24.0",
   "pnpm": {
     "overrideComments": {
       "canvas": "override from 2.8 -> 3.0 to be able to use binary dependency for resemblejs",


### PR DESCRIPTION
correctly set the pnpm versions in package.json forcing renovate-bot to use the correct one.
* add commit hook to validate package.json against .env.